### PR TITLE
add .netrc example to auth section

### DIFF
--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -32,6 +32,15 @@ These environmental variables are currently:
 - `BITBUCKET_USERNAME`
 - `BITBUCKET_PASSWORD`
 
+.netrc example:
+location: `~/.netrc`
+
+```
+machine raw.github.com
+  login visionmedia
+  password pass123
+```
+
 ### Semantic Versioning
 
 For a while, Component users were plagued by a lack of semantic versioning support.


### PR DESCRIPTION
I had to search all around for this and I ended up finding it in component-dev... It would be nice if this was in the changelogs, as the error you receive in the console links to these changelogs.

`~/.netrc`

```
machine raw.github.com
  login visionmedia
  password pass123
```
